### PR TITLE
fix: add to `x86_64-unknown-linux-musl` as well, don't readd if present in config

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
         mkdir -p "$HOME/.cargo"
         for libc in gnu musl; do
           TARGET="target.${target_arch}-unknown-linux-${libc}"
-          if ! [[ $(grep "${TARGET}" ".cargo/config.toml") ]]; then
+          if ! grep "${TARGET}" ".cargo/config.toml" 2>/dev/null; then
                 echo -e "# Added by wild GitHub Action\n[${TARGET}]\nlinker = \"clang\"\nrustflags = [\"-Clink-arg=--ld-path=${RUNNER_TEMP}/wild-install/wild\"]\n" >>"$HOME/.cargo/config.toml"
           fi
         done

--- a/action.yml
+++ b/action.yml
@@ -32,3 +32,4 @@ runs:
           fi
         done
       shell: bash
+      if: runner.os == 'Linux'

--- a/action.yml
+++ b/action.yml
@@ -25,5 +25,10 @@ runs:
           | tar -xz -C "${RUNNER_TEMP}/wild-install" --strip-components=1
 
         mkdir -p "$HOME/.cargo"
-        echo -e "# Added by wild GitHub Action\n[target.${target_arch}-unknown-linux-gnu]\nlinker = \"clang\"\nrustflags = [\"-Clink-arg=--ld-path=${RUNNER_TEMP}/wild-install/wild\"]\n" >>"$HOME/.cargo/config.toml"
+        for libc in gnu musl; do
+          TARGET="target.${target_arch}-unknown-linux-${libc}"
+          if ! [[ $(grep "${TARGET}" ".cargo/config.toml") ]]; then
+                echo -e "# Added by wild GitHub Action\n[${TARGET}]\nlinker = \"clang\"\nrustflags = [\"-Clink-arg=--ld-path=${RUNNER_TEMP}/wild-install/wild\"]\n" >>"$HOME/.cargo/config.toml"
+          fi
+        done
       shell: bash


### PR DESCRIPTION
fixes #13
fixes #15 
fixes #16

- adds `wild` to `x86_64-unknown-linux-musl`
- doesn't add to file if target with config exists
- makes it only run on linux

works as expected, proof: https://github.com/jarjk/fit2gpx-rs/actions/runs/18232239335
