### PR TITLE
hot-fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ you can instead do:
 This action writes the following to `~/.cargo/config.toml`:
 
 ```toml
-[target.${target_arch}-unknown-linux-gnu]
+[target.${target_arch}-unknown-linux-(gnu|musl)]
 linker = "clang"
 rustflags = ["-Clink-arg=--ld-path=${{ github.action_path }}/wild"]
 ```

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
         mkdir -p "$HOME/.cargo"
         for libc in gnu musl; do
           TARGET="target.${target_arch}-unknown-linux-${libc}"
-          if ! grep "${TARGET}" ".cargo/config.toml" 2>/dev/null; then
+          if ! grep "${TARGET}" "$HOME/.cargo/config.toml" 2>/dev/null; then
                 echo -e "# Added by wild GitHub Action\n[${TARGET}]\nlinker = \"clang\"\nrustflags = [\"-Clink-arg=--ld-path=${RUNNER_TEMP}/wild-install/wild\"]\n" >>"$HOME/.cargo/config.toml"
           fi
         done


### PR DESCRIPTION
sorry, as I updated the runner to the `@latest`, it turned out not be as good as I thought, despite local mocked checks.

should be good by now ;)

> [!NOTE]
> only works on `gnu` libc runners, as first of all, I have no idea how to find out if `musl` is in use, and there are no prebuilt binaries for `musl`

**commits**:

- *fix*: use correct cargo config path for checking
- *docs*: links not only `gnu`, but `musl` libc as well
