### PR TITLE
feat: add retries for `wild` downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,12 @@ then that will override the effect of this action.
 | Input | Default | Description |
 | --- | --- | --- |
 | `wild-version` | `0.8.0` | Wild version to install. |
-| `download-retries` | `5` | Number of times to retry the download on transient failures (passed to `curl --retry`). |
-| `download-retry-delay` | `2` | Delay in seconds between download retry attempts (passed to `curl --retry-delay`). |
+| `download-retries` | `5` | Number of times to retry the download on transient failures (passed to `curl --retry`). curl uses exponential backoff between retries (1s, 2s, 4s, …), so the default of 5 retries spans roughly 30 seconds. |
 
-Example overriding the retry behaviour:
+Example overriding the retry count:
 
 ```yml
       - uses: wild-linker/action@latest
         with:
-          download-retries: "10"
-          download-retry-delay: "5"
+          download-retries: "6"
 ```

--- a/README.md
+++ b/README.md
@@ -38,3 +38,20 @@ rustflags = ["-Clink-arg=--ld-path=${{ github.action_path }}/wild"]
 
 If you specify `rustflags` via a `.cargo/config.toml` in your repository or by setting `RUSTFLAGS`,
 then that will override the effect of this action.
+
+## Inputs
+
+| Input                  | Default | Description                                                                                       |
+| ---------------------- | ------- | ------------------------------------------------------------------------------------------------- |
+| `wild-version`         | `0.8.0` | Wild version to install.                                                                          |
+| `download-retries`     | `5`     | Number of times to retry the Wild download on transient failures (passed to `curl --retry`).      |
+| `download-retry-delay` | `2`     | Delay in seconds between download retry attempts (passed to `curl --retry-delay`).                |
+
+Example overriding the retry behaviour:
+
+```yml
+      - uses: wild-linker/action@latest
+        with:
+          download-retries: "10"
+          download-retry-delay: "5"
+```

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ then that will override the effect of this action.
 
 ## Inputs
 
-| Input                  | Default | Description                                                                                       |
-| ---------------------- | ------- | ------------------------------------------------------------------------------------------------- |
-| `wild-version`         | `0.8.0` | Wild version to install.                                                                          |
-| `download-retries`     | `5`     | Number of times to retry the Wild download on transient failures (passed to `curl --retry`).      |
-| `download-retry-delay` | `2`     | Delay in seconds between download retry attempts (passed to `curl --retry-delay`).                |
+| Input | Default | Description |
+| --- | --- | --- |
+| `wild-version` | `0.8.0` | Wild version to install. |
+| `download-retries` | `5` | Number of times to retry the download on transient failures (passed to `curl --retry`). |
+| `download-retry-delay` | `2` | Delay in seconds between download retry attempts (passed to `curl --retry-delay`). |
 
 Example overriding the retry behaviour:
 

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,19 @@ runs:
 
         mkdir "${RUNNER_TEMP}/wild-install"
 
-        curl --silent -L \
-          "https://github.com/wild-linker/wild/releases/download/${{ inputs.wild-version }}/wild-linker-${{ inputs.wild-version }}-${target_arch}-unknown-linux-gnu.tar.gz" \
-          | tar -xz -C "${RUNNER_TEMP}/wild-install" --strip-components=1
+        url="https://github.com/wild-linker/wild/releases/download/${{ inputs.wild-version }}/wild-linker-${{ inputs.wild-version }}-${target_arch}-unknown-linux-gnu.tar.gz"
+        archive="${RUNNER_TEMP}/wild.tar.gz"
+
+        # Download with retries and proper error reporting so a transient
+        # CDN/redirect glitch doesn't manifest as a confusing
+        # "gzip: stdin: not in gzip format" tar failure.
+        curl --fail-with-body --show-error --location \
+             --retry 5 --retry-all-errors --retry-delay 2 \
+             --output "${archive}" \
+             "${url}"
+
+        tar -xzf "${archive}" -C "${RUNNER_TEMP}/wild-install" --strip-components=1
+        rm -f "${archive}"
 
         mkdir -p "$HOME/.cargo"
         for libc in gnu musl; do

--- a/action.yml
+++ b/action.yml
@@ -22,10 +22,6 @@ runs:
 
         url="https://github.com/wild-linker/wild/releases/download/${{ inputs.wild-version }}/wild-linker-${{ inputs.wild-version }}-${target_arch}-unknown-linux-gnu.tar.gz"
         archive="${RUNNER_TEMP}/wild.tar.gz"
-
-        # Download with retries and proper error reporting so a transient
-        # CDN/redirect glitch doesn't manifest as a confusing
-        # "gzip: stdin: not in gzip format" tar failure.
         curl --fail-with-body --show-error --location \
              --retry 5 --retry-all-errors --retry-delay 2 \
              --output "${archive}" \

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,14 @@ inputs:
     description: "Wild version to use"
     required: false
     default: "0.8.0"
+  download-retries:
+    description: "Number of times to retry the Wild download on transient failures (passed to curl --retry)."
+    required: false
+    default: "5"
+  download-retry-delay:
+    description: "Delay in seconds between download retry attempts (passed to curl --retry-delay)."
+    required: false
+    default: "2"
 
 runs:
   using: "composite"
@@ -23,7 +31,8 @@ runs:
         url="https://github.com/wild-linker/wild/releases/download/${{ inputs.wild-version }}/wild-linker-${{ inputs.wild-version }}-${target_arch}-unknown-linux-gnu.tar.gz"
         archive="${RUNNER_TEMP}/wild.tar.gz"
         curl --fail-with-body --show-error --location \
-             --retry 5 --retry-all-errors --retry-delay 2 \
+             --retry "${{ inputs.download-retries }}" --retry-all-errors \
+             --retry-delay "${{ inputs.download-retry-delay }}" \
              --output "${archive}" \
              "${url}"
 

--- a/action.yml
+++ b/action.yml
@@ -8,13 +8,9 @@ inputs:
     required: false
     default: "0.8.0"
   download-retries:
-    description: "Number of times to retry the Wild download on transient failures (passed to curl --retry)."
+    description: "Number of times to retry the Wild download on transient failures (passed to curl --retry). curl uses exponential backoff between retries."
     required: false
     default: "5"
-  download-retry-delay:
-    description: "Delay in seconds between download retry attempts (passed to curl --retry-delay)."
-    required: false
-    default: "2"
 
 runs:
   using: "composite"
@@ -32,7 +28,6 @@ runs:
         archive="${RUNNER_TEMP}/wild.tar.gz"
         curl --fail-with-body --show-error --location \
              --retry "${{ inputs.download-retries }}" --retry-all-errors \
-             --retry-delay "${{ inputs.download-retry-delay }}" \
              --output "${archive}" \
              "${url}"
 


### PR DESCRIPTION
The install step pipes curl straight into tar. On a transient download failure the job fails with a misleading `gzip: stdin: not in gzip format` instead of retrying.

This PR splits download and extract, and uses `curl --retry` to handle transient failures. Retry count and delay are exposed as inputs (`download-retries`, `download-retry-delay`) with sensible defaults, so existing users need no changes.